### PR TITLE
Corrected initial facility selection checks.

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -351,14 +351,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
     public function selectionEligible()
     {
-        if ($this->flag_homecontroller == 0) {
-            return false;
-        }
-
-        if ($this->facility == "ZAE" && !$this->flag_needbasic && Transfers::where('cid', $this->cid)->where('to',
-                'NOT LIKE', 'ZAE')->where('to', 'NOT LIKE', 'ZZN')->count() < 1) //        if($this->facility == "ZAE")
-        {
+        // If user is in VATUSA, is in Academy, and does not need basic exam.
+        if ($this->flag_homecontroller == 1 && $this->facility == "ZAE" && !$this->flag_needbasic) {
             return true;
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION
Prior to these changes, the **selectionEligible()** method would check to see if the user was ever part of a facility by looking through their transfer history. I deemed this as unnecessary and identified it as the source of the bug that would not allow users to select a facility upon rejoining the VATUSA division.