### PR TITLE
Allow viewing TRs and OTS Evaluations from own facility

### DIFF
--- a/app/Http/Controllers/MgtController.php
+++ b/app/Http/Controllers/MgtController.php
@@ -66,7 +66,12 @@ class MgtController extends Controller
 
             /** Training Records */
             $trainingfac = $request->input('fac', null);
-            $trainingfaclist = $user->trainingRecords()->groupBy('facility_id')->get();
+            $trainingfaclist = $user->trainingRecords()->groupBy('facility_id')->get()->filter(function ($record) use (
+                $user
+            ) {
+                return Auth::user()->facility === $record->facility_id || Auth::user()->facility === $user->facility || $user->visits()->where('facility',
+                        Auth::user()->facility)->exists();
+            });
 
             if (!$trainingfac) {
                 if ($trainingfaclist->count() == 1) {
@@ -83,7 +88,7 @@ class MgtController extends Controller
                     abort(500);
                 }
             }
-            $trainingRecords = $user->facility == Auth::user()->facility || $user->visits()->where('facility',
+            $trainingRecords = $user->facility == Auth::user()->facility || $trainingfac == Auth::user()->facility || $user->visits()->where('facility',
                 Auth::user()->facility)->exists() || RoleHelper::isVATUSAStaff() ? $user->trainingRecords()->where('facility_id',
                 $trainingfac)->get() : [];
             $canAddTR = RoleHelper::isTrainingStaff(Auth::user()->cid, true,

--- a/resources/views/mgt/controller/index.blade.php
+++ b/resources/views/mgt/controller/index.blade.php
@@ -216,9 +216,9 @@
                         <li role="presentation"><a href="#exams" aria-controls="exams" role="tab"
                                                    data-toggle="tab">Exams</a></li>
                     @endif
-                    @php $canViewTraining = $user->facility == Auth::user()->facility || $user->visits()->where('facility', Auth::user()->facility)->exists() || \App\Classes\RoleHelper::isVATUSAStaff() @endphp
+                    @php $canViewTraining = $user->facility == Auth::user()->facility || $user->visits()->where('facility', Auth::user()->facility)->exists() || $user->trainingRecords()->where('facility_id', Auth::user()->facility)->exists() || \App\Classes\RoleHelper::isVATUSAStaff() @endphp
                     <li role="presentation" @if(!$canViewTraining) class="disabled" rel="tooltip"
-                        title="Not a home or visiting controller at your ARTCC" @endif><a href="#training"
+                        title="Not a home or visiting controller at your ARTCC or does not have any records from your ARTCC." @endif><a href="#training"
                                                                                           @if($canViewTraining) data-controls="training"
                                                                                           role="tab"
                                                                                           data-toggle="tab" @endif>Training</a>

--- a/resources/views/mgt/controller/training/training.blade.php
+++ b/resources/views/mgt/controller/training/training.blade.php
@@ -55,7 +55,7 @@
                 <!-- Filters: Major/Minor | Sweatbox/Live | OTS -->
                 @php $postypes = ['OTS', 'DEL', 'GND', 'TWR', 'APP', 'CTR']; @endphp
                 <div role="tabpanel" class="tab-pane active" id="all">
-                    @if($trainingRecords->count() && $trainingfaclist->count())
+                    @if(!is_array($trainingRecords) && $trainingRecords->count() && $trainingfaclist->count())
                         <table class="training-records-list table table-striped" id="training-records-all">
                             <thead>
                             <tr>
@@ -149,7 +149,7 @@
                 @foreach($postypes as $postype)
                     <div role="tabpanel" class="tab-pane"
                          id="{{strtolower($postype)}}">
-                        @if($trainingRecords->count() && $trainingfaclist->count())
+                        @if(!is_array($trainingRecords) && $trainingRecords->count() && $trainingfaclist->count())
                             @php $records = $trainingRecords->filter(function($record) use ($postype) {
                                                                     return $postype == "OTS" ? in_array($record->ots_status, [1,2]) : preg_match("/$postype\$/", $record->position);
                                                                     })


### PR DESCRIPTION
This update addresses #47. Training staff members will now be able to retain the ability to view training records and OTS evaluations that originated in their facility even if the controller transfers out.