### PR TITLE
Hide enroll button for current rating

### DIFF
--- a/resources/views/mgt/controller/index.blade.php
+++ b/resources/views/mgt/controller/index.blade.php
@@ -588,7 +588,7 @@
                                                                         Enrolled</strong>
                                                                     on
                                                                     {{ $data['assignDate'] }}
-                                                                @elseif($data['examInfo']['id'] === config('exams.BASIC.id'))
+                                                                @elseif($data['examInfo']['id'] === config('exams.BASIC.id') || $data['examInfo']['rating'] <= $user->rating)
                                                                     <em>Auto-Enrolled</em>
                                                                 @elseif($data['examInfo']['rating'] - 1 <= $user->rating)
                                                                     @if(\App\Classes\RoleHelper::isFacilitySeniorStaff() || \App\Classes\RoleHelper::isInstructor())

--- a/resources/views/my/training/academy.blade.php
+++ b/resources/views/my/training/academy.blade.php
@@ -53,8 +53,9 @@
                 @elseif ($data['assignDate'] || $data['examInfo']['id'] === config('exams.BASIC.id') || $data['examInfo']['rating'] <= Auth::user()->rating)
                     <strong class="text-success"><i
                             class="fas fa-user-check"></i> Enrolled</strong>
-                    on
-                    {{ $data['assignDate'] }}
+                    @if($data['assignDate']) on 
+                        {{ $data['assignDate'] }}
+                    @endif
                 @elseif($data['examInfo']['rating'] - 1 <= Auth::user()->rating)
                     <span
                         class="label label-danger"><i class="fas fa-times-circle"

--- a/resources/views/my/training/academy.blade.php
+++ b/resources/views/my/training/academy.blade.php
@@ -50,13 +50,11 @@
                 @if($hasPassed)
                     <strong style="color: #39683a"><em><i
                                 class="fas fa-check-double"></i> Course Complete</em></strong>
-                @elseif ($data['assignDate'])
+                @elseif ($data['assignDate'] || $data['examInfo']['id'] === config('exams.BASIC.id') || $data['examInfo']['rating'] <= Auth::user()->rating)
                     <strong class="text-success"><i
                             class="fas fa-user-check"></i> Enrolled</strong>
                     on
                     {{ $data['assignDate'] }}
-                @elseif($data['examInfo']['id'] === config('exams.BASIC.id'))
-                    <em>Auto-Enrolled</em>
                 @elseif($data['examInfo']['rating'] - 1 <= Auth::user()->rating)
                     <span
                         class="label label-danger"><i class="fas fa-times-circle"


### PR DESCRIPTION
This update hides the enroll button if the user’s rating is greater than or equal to the exam course rating.