### PR TITLE
Reorganize Menu for better UX

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -89,6 +89,7 @@
             </div>
             <div id="navbar" class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
+                     <li><a href="/"><i class="fas fa-home"></i> Home</a></li>
                     <li><a href="https://academy.vatusa.net"><i class="fas fa-graduation-cap"></i> Academy</a></li>
                     <li><a href="{{ secure_url("/help/kb") }}"><i class="fas fa-question-circle"></i> FAQ</a></li>
                     <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
@@ -123,6 +124,11 @@
                             Division Info <span class="caret"></span>
                         </a>
                         <ul class="dropdown-menu" role="menu">
+                            @if(!Auth::check())
+                                <li><a href="/tmu/notices" target="_blank">N.T.O.S. - TMU Notices</a></li>
+                                <li class="divider"></li>
+                            @else
+                            
                             <li><a href="https://discord.gg/a7Qcse7" target="_blank"><i class="fab fa-discord"></i>
                                     Official Discord</a></li>
                             <li><a href="https://forums.vatusa.net"><i class="fas fa-comment"></i> Forums</a></li>
@@ -202,9 +208,6 @@
                     @if((Auth::check() && !Auth::user()->facility()->active && Auth::user()->facility != "ZHQ") || !Auth::check())
                         <li class="dropdown"><a href="/info/join">Join Us</a></li>
                     @endif
-                    @if(!Auth::check())
-                        <li><a href="/tmu/notices" target="_blank">N.T.O.S. - TMU Notices</a></li>
-                    @else
                         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
                                                 aria-expanded="false">
                                 TMU Maps


### PR DESCRIPTION
Moved around a few things and added back the home button to make more space, and to give a more natural UX than what it currently is. The "N.T.O.S. - TMU Notices" is barely used, especially by pilots - and takes up twice the space that of any other menu item, so it's been moved to a sub-menu. It's also not important to have that button there, since any relevant TMU notices gets shown on the front page anyway, so 90% of the week, it is a useless button.