### PR TITLE
Remove incorrect VATUSA staff reference from ACE

### DIFF
--- a/resources/views/info/ace.blade.php
+++ b/resources/views/info/ace.blade.php
@@ -10,7 +10,7 @@
             </div>
             <div class="panel-body">
                 <strong>What is the ACE Team?</strong>
-                <p>The VATUSA Advanced Controller for Events (ACE) Team is a group of highly skilled advanced controllers who have volunteered to make themselves available for assisting USA Facilities with event staffing. Each member represents the best of VATUSA controlling ability and are exceptional controllers. Facilities in need of the ACE Team should contact the VATUSA Command Center Manager (VATUSA9) to schedule the team for an event.</p>
+                <p>The VATUSA Advanced Controller for Events (ACE) Team is a group of highly skilled advanced controllers who have volunteered to make themselves available for assisting USA Facilities with event staffing. Each member represents the best of VATUSA controlling ability and are exceptional controllers.</p>
                 <hr>
                 <table class="table table-hover">
                     <thead>


### PR DESCRIPTION
No need to refer to VATUSA9... who no longer holds responsibility for events.  Rather than updating this every time we change numbers, seems simpler to remove the sentence and rely on the ability of the ARTCC staffs to properly request ACE support.