### PR TITLE
Remove extra "control facility"

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -68,8 +68,7 @@
                                 ({{Auth::user()->urating->long}})<br>
                                 <i class="fa fa-star"></i> {{\App\Classes\RoleHelper::getUserRole(Auth::user()->cid, Auth::user()->facility)}}
                                 - {{\App\Classes\Helper::facShtLng(Auth::user()->facility)}}
-                                {{(!empty(Auth::user()->facility) && (Auth::user()->facility != 'HCF' && Auth::user()->facility != 'ZHQ' && !preg_match('/^ZZ/', Auth::user()->facility)) ? '' : '')}}
-                                {{(!empty(Auth::user()->facility) && Auth::user()->facility == 'HCF' ? 'Control Facility' : '')}}
+                                {{(!empty(Auth::user()->facility) && (Auth::user()->facility != 'ZHQ' && !preg_match('/^ZZ/', Auth::user()->facility)) ? '' : '')}}
                             </small>
                         </div>
                     </div>


### PR DESCRIPTION
Profile currently shows "Honolulu CF Control Facility", no need to say CF twice
![image](https://github.com/VATUSA/current/assets/97543307/82899cfc-87a2-4910-8e28-2fb906feb067)
