### PR TITLE
Fix ticket assignee name

### DIFF
--- a/resources/views/help/viewticket.blade.php
+++ b/resources/views/help/viewticket.blade.php
@@ -63,8 +63,7 @@
                                         </select>
                                     @else
                                         @if ($ticket->assigned_to)
-                                            <p class="form-control-static">{{$ticket->assignedto->fullname()}}
-                                                ($ticket->assigned_to)</p>
+                                            <p class="form-control-static">{{$ticket->assignedto->fullname()}}</p>
                                         @else
                                             <p class="form-control-static">Unassigned</p>
                                         @endif


### PR DESCRIPTION
The ticket assignee was previously showing the CID variable name. This PR removes that part entirely, showing only the assignee's name to the non-staff-member viewing the ticket.


_Did I actually just submit a pull request?!?!? Wow._