### PR TITLE
Fix: Academy Transcript tab hidden for mentors viewing students with records from a previous facility

### DIFF
--- a/app/Http/Controllers/MgtController.php
+++ b/app/Http/Controllers/MgtController.php
@@ -111,6 +111,8 @@ class MgtController extends Controller
                     ? $user->trainingRecords()->where('facility_id', $trainingfac)->get() : [];
             $canAddTR = AuthHelper::authACL()->canCreateTrainingRecords($trainingfac)
                 && $user->cid !== Auth::user()->cid;
+            $canViewTraining = AuthHelper::authACL()->canViewTrainingRecords($trainingfac)
+                || AuthHelper::authACL()->canViewTrainingRecords($user->facility);
 
             Log::info("MgtController: Starting Moodle interaction for CID: $cid.");
             $moodle = new VATUSAMoodle();
@@ -157,7 +159,7 @@ class MgtController extends Controller
 
             return view('mgt.controller.index',
                 compact('user', 'checks', 'eligible', 'trainingRecords', 'trainingFacListArray', 'trainingfac',
-                    'trainingfacname', 'canAddTR', 'examAttempts', 'moodleUid', 'assignedRoles'));
+                    'trainingfacname', 'canAddTR', 'canViewTraining', 'examAttempts', 'moodleUid', 'assignedRoles'));
         } else {
             if ($user = User::where('discord_id', $cid)->first()) {
                 return redirect()->route('mgt.controller.index', ['cid' => $user->cid]);

--- a/resources/views/mgt/controller/index.blade.php
+++ b/resources/views/mgt/controller/index.blade.php
@@ -134,7 +134,6 @@
                                                    data-toggle="tab">Ratings
                                 &amp; Transfers</a></li>
                     @endif
-                    @php $canViewTraining = \App\Helpers\AuthHelper::authACL()->canViewTrainingRecords($trainingfac) @endphp
                     @if($canViewTraining)
                         <li role="presentation"><a href="#exams" aria-controls="exams" role="tab"
                                                    data-toggle="tab">Academy Transcript</a></li>


### PR DESCRIPTION
## Problem

When a mentor views a student controller's management page, the **Academy Transcript** tab (which shows exam history and course enrollments) was not visible under certain conditions — even when the mentor had full rights to see it.

This happened when a student had training records *only* from a facility they previously trained at (e.g., ZBW), but are now homed at the mentor's facility (e.g., ZMA). The tab would silently disappear, giving the mentor no indication that transcript data existed at all.

## Root Cause

The page has two separate places that decide whether the mentor can see the transcript tab, and they used different logic:

1. **The controller** (server-side, before the page renders) fetches the actual transcript data using a permissive check: *"can the viewer see records for this specific training facility, OR can they see records for the student's current home facility?"*

2. **The view template** (what generates the HTML) re-ran its own access check to decide whether to show the tab — but only used the first half of that condition, without the "or home facility" fallback.

So when a student's only training records were from ZBW, the controller correctly loaded the data, but the template checked "can this ZMA mentor see ZBW records?", got "no", and hid the tab entirely. The data was there; the door was just incorrectly locked.

## Fix

The access check is now computed once in the controller, using the same complete condition already used to load the data, and passed directly to the template. The template no longer independently recalculates it — there's one source of truth, and the tab visibility matches the data loading logic exactly.