### PR TITLE
Implement Cobalt-driven auth for legacy site

### DIFF
--- a/app/Cobalt/CobaltSession.php
+++ b/app/Cobalt/CobaltSession.php
@@ -10,7 +10,36 @@ class CobaltSession
 
     function __construct(array $json) {
         $this->user = new CobaltUser($json['user']);
+    }
 
+    /**
+     * Extract the CID from a cobalt JWT.
+     *
+     * Fast path: decode the JWT locally with the shared key (no network call).
+     * Fallback: call cobalt /tokenSession if local decode fails (key mismatch, etc.).
+     */
+    public static function getCidFromToken(string $token): ?int
+    {
+        $jwtKey = config('cobalt.jwt_key', '');
+
+        if (!empty($jwtKey) && class_exists(\Firebase\JWT\JWT::class)) {
+            try {
+                $decoded = \Firebase\JWT\JWT::decode($token, new \Firebase\JWT\Key($jwtKey, 'HS256'));
+                $cid = (int) ($decoded->cid ?? 0);
+                if ($cid > 0) {
+                    return $cid;
+                }
+            } catch (\Throwable $e) {
+                // Fall through to /tokenSession
+            }
+        }
+
+        $json = CobaltAPIHelper::getUserSessionFromToken($token);
+        if ($json === null) {
+            return null;
+        }
+        $cid = (int) ($json['user']['cid'] ?? 0);
+        return $cid > 0 ? $cid : null;
     }
 
     public static function fetchFromToken($token): ?CobaltSession {

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,56 +2,29 @@
 
 namespace App\Http\Controllers;
 
-use App\Classes\Helper;
-use App\Classes\RoleHelper;
 use App\Classes\SMFHelper;
-use App\Classes\VATUSAMoodle;
-use App\Cobalt\CobaltSession;
-use App\Models\User;
 use Auth;
 use Illuminate\Http\Request;
 
 class AuthController extends Controller {
-    /**
-     * Create a new controller instance.
-     *
-     * @return void
-     */
+
     public function __construct() {
         $this->middleware('guest');
     }
 
-    /**
-     * Show the application welcome screen to the user.
-     *
-     * @return \Illuminate\Http\RedirectResponse
-     */
     public function getLogin(Request $request) {
-        if ($request->hasCookie("vatusa-cobalt-token")) {
-            $token = $request->cookie("vatusa-cobalt-token");
-            $session = CobaltSession::fetchFromToken($token);
-            Auth::loginUsingId($session->user->cid, true);
-        }
+        // Dev auto-login when no cobalt token is present
         if (config('app.env', 'prod') == "dev" && !\Auth::check()) {
-            /** In Development Environment */
             Auth::loginUsingId(config('app.dev_cid_login', 0), true);
-            /*$moodle = new VATUSAMoodle(true);
-            $response = $moodle->request("auth_userkey_request_login_url",
-                ['user' => ['idnumber' => \Illuminate\Support\Facades\Auth::user()->cid]]);
-            $url = $response["loginurl"];
-
-            return redirect($url . "&wantsurl=" . urlencode("https://www.vatusa.devel"));*/
         }
         if (!Auth::check()) {
-            //If agreed on privacy policy, redirect to profile (opt in setting)
-            //Otherwise, normal redirect to home
             $return = request()->has('agreed') ? "agreed" : config('app.login_env');
-
+            if (config('cobalt.use_cobalt_login')) {
+                return redirect(rtrim(config('cobalt.login_url'), '/') . '/?' . $return);
+            }
             return redirect()->guest(config('app.loginUrl') . "/?" . $return);
-        } else {
-            SMFHelper::setPermissions(Auth::user()->cid);
         }
-
+        SMFHelper::setPermissions(Auth::user()->cid);
         return redirect()->intended('/');
     }
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends HttpKernel
         'Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse',
         'Illuminate\Session\Middleware\StartSession',
         'Illuminate\View\Middleware\ShareErrorsFromSession',
+        'App\Http\Middleware\CobaltAuthBridge',
     ];
 
     /**

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,56 +1,29 @@
 <?php namespace App\Http\Middleware;
 
-use App\Cobalt\CobaltSession;
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
 
 class Authenticate {
 
-	/**
-	 * The Guard implementation.
-	 *
-	 * @var Guard
-	 */
 	protected $auth;
 
-	/**
-	 * Create a new filter instance.
-	 *
-	 * @param  Guard  $auth
-	 * @return void
-	 */
 	public function __construct(Guard $auth)
 	{
 		$this->auth = $auth;
 	}
 
-	/**
-	 * Handle an incoming request.
-	 *
-	 * @param  \Illuminate\Http\Request  $request
-	 * @param  \Closure  $next
-	 * @return mixed
-	 */
 	public function handle($request, Closure $next)
 	{
 		if ($this->auth->guest())
 		{
-            if ($request->hasCookie("vatusa-cobalt-token")) {
-                $token = $request->cookie("vatusa-cobalt-token");
-                $session = CobaltSession::fetchFromToken($token);
-                if ($session !== null) {
-                    \Auth::loginUsingId($session->user->cid, true);
-                    return $next($request);
-                }
-            }
 			if ($request->ajax())
 			{
 				return response('Unauthorized.', 401);
 			}
-			else
-			{
-				return redirect()->guest('login');
+			if (config('cobalt.use_cobalt_login')) {
+				return redirect(config('cobalt.login_url'));
 			}
+			return redirect()->guest('login');
 		}
 
 		return $next($request);

--- a/app/Http/Middleware/CobaltAuthBridge.php
+++ b/app/Http/Middleware/CobaltAuthBridge.php
@@ -1,0 +1,27 @@
+<?php namespace App\Http\Middleware;
+
+use App\Cobalt\CobaltSession;
+use Closure;
+use Illuminate\Http\Request;
+
+class CobaltAuthBridge
+{
+    /**
+     * On every request, if Laravel has no session, check for a cobalt JWT cookie
+     * and log the user in from it. This runs globally so that any page load
+     * (not just auth-guarded routes) picks up an active cobalt session.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (\Auth::guest()) {
+            $cookieName = config('cobalt.cookie_name', 'vatusa-cobalt-token');
+            if ($request->hasCookie($cookieName)) {
+                $cid = CobaltSession::getCidFromToken($request->cookie($cookieName));
+                if ($cid !== null) {
+                    \Auth::loginUsingId($cid, true);
+                }
+            }
+        }
+        return $next($request);
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,8 +26,16 @@ Route::group([
     Route::get('/login', 'AuthController@getLogin');
     Route::get('/logout', function () {
         \Auth::logout();
-
-        return redirect("/");
+        if (config('cobalt.use_cobalt_login')) {
+            // Cobalt logout clears the JWT cookie at the source and redirects to POST_LOGIN_URL
+            return redirect(rtrim(config('cobalt.login_url'), '/') . '/logout');
+        }
+        // Clear the cobalt cookie locally so the bridge doesn't silently re-log the user in
+        return redirect('/')->withCookie(\Cookie::forget(
+            config('cobalt.cookie_name', 'vatusa-cobalt-token'),
+            '/',
+            config('cobalt.cookie_domain', '')
+        ));
     });
     Route::get('/news/page/{page?}', 'NewsController@getIndex');
     Route::get('/news/post/{postId}', 'NewsController@getPost');

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 		"laravel/helpers": "^1.4",
 		"league/flysystem-aws-s3-v3": "*",
 		"spatie/laravel-html": "*",
-		"fakerphp/faker": "^1.24"
+		"fakerphp/faker": "^1.24",
+		"firebase/php-jwt": "^6.0"
     },
 	"require-dev": {
 		"phpunit/phpunit": "^9.0",

--- a/config/cobalt.php
+++ b/config/cobalt.php
@@ -3,4 +3,9 @@
 return [
     'url' => env('COBALT_URL', ''),
     'token' => env('COBALT_TOKEN', ''),
+    'jwt_key' => env('JWT_KEY', ''),
+    'cookie_name' => env('COBALT_COOKIE', 'vatusa-cobalt-token'),
+    'cookie_domain' => env('COBALT_COOKIE_DOMAIN', ''),
+    'login_url' => env('COBALT_LOGIN_URL', ''),
+    'use_cobalt_login' => env('USE_COBALT_LOGIN', false),
 ];


### PR DESCRIPTION
## Summary

- Adds a global `CobaltAuthBridge` middleware that runs on every request: if Laravel has no session and the `vatusa-cobalt-token` cookie is present, it logs the user in automatically — no longer limited to auth-guarded routes or the `/login` page
- `CobaltSession::getCidFromToken()` verifies the JWT locally (shared `JWT_KEY`, no network call) with fallback to the existing `/tokenSession` API call if local decode fails (key mismatch, library not yet installed, etc.)
- Guest redirect and logout are now env-gated: when `USE_COBALT_LOGIN=true`, guests go to the cobalt login URL and logout chains to cobalt's logout endpoint (which clears the JWT cookie at the source); the legacy `LOGIN_URL` SSO path is kept for prod until the `/legacy` cutover
- Logout also explicitly forgets the `vatusa-cobalt-token` cookie on the legacy path so the bridge can't silently re-log the user in after they sign out

## New env vars (add to `.env`)

```
JWT_KEY=<same value as cobalt's JWT_KEY>
COBALT_LOGIN_URL=<cobalt public base URL, e.g. https://vatusa.net/cobalt>
USE_COBALT_LOGIN=true          # set on dev/staging; leave false on prod for now
COBALT_COOKIE=vatusa-cobalt-token   # default, only override if changed
COBALT_COOKIE_DOMAIN=.vatusa.net    # prod; leave empty for localhost
```

## Auth flow

### First visit — no cobalt cookie yet

```mermaid
sequenceDiagram
    actor User
    participant Browser
    participant Laravel as Legacy Site (Laravel)
    participant Cobalt as Cobalt (Go API)
    participant VATSIM as VATSIM Connect

    User->>Browser: Navigate to vatusa.net/legacy
    Browser->>Laravel: GET /legacy (no cookie)
    Laravel->>Laravel: CobaltAuthBridge — no cookie, skip
    Laravel->>Laravel: Authenticate middleware — still guest
    Laravel->>Browser: 302 → COBALT_LOGIN_URL/login

    Browser->>Cobalt: GET /login
    Cobalt->>Browser: 302 → VATSIM Connect OAuth URL
    Browser->>VATSIM: OAuth flow
    VATSIM->>Browser: 302 → cobalt /login/connect?code=...
    Browser->>Cobalt: GET /login/connect?code=...
    Cobalt->>Cobalt: Mint HS256 JWT (cid, display_name, permissions)
    Cobalt->>Browser: Set vatusa-cobalt-token (Domain=vatusa.net, SameSite=Lax, 7d) + 302 → POST_LOGIN_URL

    Browser->>Laravel: GET /legacy (with vatusa-cobalt-token)
    Laravel->>Laravel: CobaltAuthBridge — cookie found, Auth::guest() true
    Laravel->>Laravel: getCidFromToken() — local HS256 decode (fast path)
    Laravel->>Laravel: Auth::loginUsingId(cid) → write Redis session
    Laravel->>Browser: Set VATUSA_token session cookie + render page
```

### Return visit — cobalt cookie present

```mermaid
sequenceDiagram
    participant Browser
    participant Laravel as Legacy Site (Laravel)
    participant Cobalt as Cobalt (Go API)
    participant Redis

    Browser->>Laravel: GET /any-page (with vatusa-cobalt-token, no Laravel session)
    Laravel->>Laravel: CobaltAuthBridge — cookie found, Auth::guest() true

    alt JWT_KEY set and firebase/php-jwt installed
        Laravel->>Laravel: JWT::decode(token, JWT_KEY, HS256) → CID (no network call)
    else local decode fails or key missing
        Laravel->>Cobalt: POST /tokenSession {token}
        Cobalt-->>Laravel: {user: {cid, ...}}
        Laravel->>Laravel: Extract CID from response
    end

    Laravel->>Redis: Auth::loginUsingId(cid, remember=true)
    Redis-->>Laravel: Session written
    Laravel->>Browser: Set VATUSA_token session cookie + render page

    Note over Browser,Redis: Subsequent requests — VATUSA_token present, CobaltAuthBridge skips (Auth::guest() false)
```

### Logout

```mermaid
sequenceDiagram
    participant Browser
    participant Laravel as Legacy Site (Laravel)
    participant Redis
    participant Cobalt as Cobalt (Go API)

    Browser->>Laravel: GET /logout
    Laravel->>Redis: Auth::logout() — destroy session

    alt USE_COBALT_LOGIN=true (dev/staging)
        Laravel->>Browser: 302 → COBALT_LOGIN_URL/logout
        Browser->>Cobalt: GET /login/logout
        Cobalt->>Browser: Clear vatusa-cobalt-token (MaxAge=-1, Domain=vatusa.net) + 302 → POST_LOGIN_URL
        Note over Browser: JWT cookie cleared at source — CobaltAuthBridge cannot re-log user in
    else USE_COBALT_LOGIN=false (prod — legacy path)
        Laravel->>Browser: 302 → / + Set-Cookie: vatusa-cobalt-token= MaxAge=0
        Note over Browser: Cookie cleared locally — bridge skipped on next request
    end
```

## Test plan

- [ ] `composer install` (adds `firebase/php-jwt ^6.0`)
- [ ] With a valid `vatusa-cobalt-token` cookie: load any page (including the home page, which is under `privacy-agree` not `auth`) and confirm you're logged in without being redirected
- [ ] Break `JWT_KEY` in `.env`; confirm the bridge falls back to `/tokenSession` and still logs you in
- [ ] With no cobalt cookie and `USE_COBALT_LOGIN=true`: confirm guests are redirected to `COBALT_LOGIN_URL`
- [ ] `/logout` with `USE_COBALT_LOGIN=true`: confirm redirect to cobalt logout and subsequent page load does **not** silently re-log you in
- [ ] `/logout` with `USE_COBALT_LOGIN=false`: confirm redirect to `/` and cobalt cookie is cleared
- [ ] With `USE_COBALT_LOGIN=false` (prod-like): confirm legacy `LOGIN_URL` SSO path is unchanged