### PR TITLE
Update missing authentication call

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -49,7 +49,6 @@ Route::group([
          *  AJAX  *
          * * * * * */
         Route::group(['prefix' => 'ajax'], function () {
-            Route::get('/cid', 'AJAXController@getCID');
             Route::get('/events', 'AJAXController@getEvents');
             Route::get('/news', 'AJAXController@getNews');
             Route::get('/help/staffc/{facility}', 'AJAXController@getHelpStaffc');
@@ -64,6 +63,8 @@ Route::group([
         });
         Route::get('/help/kb', 'HelpdeskController@getKBIndex');
         Route::group(['middleware' => 'auth'], function () {
+            Route::get('ajax/cid', 'AJAXController@getCID');
+
             Route::group(['prefix' => 'help'], function () {
                 Route::group(['prefix' => 'kbe'], function () {
                     Route::get('/', 'HelpdeskController@getKBE');


### PR DESCRIPTION
## Require authentication on `/ajax/cid`

### Summary

`GET /ajax/cid` (`AJAXController@getCID`) was registered in the public `ajax` route group, alongside genuinely public endpoints like `/ajax/events` and `/ajax/news`. Unlike those, `getCID` returns real member names/CIDs for autocomplete — its only known consumer is the admin-only controller promotion form (`resources/views/mgt/controller/promotion.blade.php`). It had no authentication check anywhere (no route middleware, no controller-level check), so any unauthenticated caller could enumerate member names by partial CID match.

This moves the route out of the public `ajax` group and into the existing `auth`-protected group in `app/Http/routes.php` (same one that already gates `/help/kbe/*`, `/help/ticket/*`, `/my/*`, etc.). URL is unchanged (`/ajax/cid`); the other `ajax/*` routes remain public since they're intentionally so.

### Test plan

- [x] Built the `vatusa/www` Docker image with this change and ran `php artisan route:list --json` inside the container — confirmed `/ajax/cid` now carries `['csrf', 'lastactivity', 'privacy-agree', 'auth']`, identical to a known auth-protected route (`/my/profile`)
- [ ] Confirm unauthenticated request to `/ajax/cid` is redirected/rejected
- [ ] Confirm the controller promotion form's autocomplete still works when logged in as staff