### PR TITLE
Stop fetching full quiz attempt review just to read the grade

### DIFF
--- a/app/Classes/VATUSAMoodle.php
+++ b/app/Classes/VATUSAMoodle.php
@@ -51,6 +51,9 @@ class VATUSAMoodle extends MoodleRest
     public const CONTEXT_MODULE = 70;
     public const CONTEXT_BLOCK = 80;
 
+    /** @var array Memoized quiz grade/sumgrades rows, keyed by quiz id */
+    private $quizMetaCache = [];
+
     /**
      * VATUSAMoodle constructor.
      *
@@ -629,7 +632,31 @@ class VATUSAMoodle extends MoodleRest
     }
 
     /**
+     * Get quiz grade/sumgrades, memoized per quiz id for the lifetime of this instance.
+     *
+     * @param int $quizId The Quiz ID
+     *
+     * @return object|null
+     */
+    public
+    function getQuizMeta(
+        int $quizId
+    ) {
+        if (!array_key_exists($quizId, $this->quizMetaCache)) {
+            $this->quizMetaCache[$quizId] = DB::connection('moodle')->table('quiz')
+                ->where('id', $quizId)
+                ->first(['grade', 'sumgrades']);
+        }
+
+        return $this->quizMetaCache[$quizId];
+    }
+
+    /**
      * Get quiz attempts
+     *
+     * Grades are computed from the Moodle database (quiz.grade/sumgrades and
+     * quiz_attempts.sumgrades) rather than via the mod_quiz_get_attempt_review web service,
+     * which returns the entire rendered attempt review (~2 MB) to read a single number.
      *
      * @param int      $quizid The Quiz ID
      * @param int|null $cid    The user's CID
@@ -652,14 +679,20 @@ class VATUSAMoodle extends MoodleRest
             $attempts = $this->request("mod_quiz_get_user_attempts",
                     ["quizid" => $quizid, "userid" => $userid])['attempts'] ?? [];
 
-            for ($i = 0; $i < count($attempts); $i++) {
-                $review = $this->request("mod_quiz_get_attempt_review",
-                        ["attemptid" => $attempts[$i]['id']]) ?? [];
-                if (!empty($review)) {
-                    $attempts[$i]['grade'] = round(floatval($review['grade']));
-                } else {
+            $quiz = $this->getQuizMeta($quizid);
+            if (!$quiz || !$quiz->sumgrades) {
+                return [];
+            }
+
+            $sumgrades = DB::connection('moodle')->table('quiz_attempts')
+                ->whereIn('id', array_column($attempts, 'id'))
+                ->pluck('sumgrades', 'id');
+
+            foreach ($attempts as $i => $attempt) {
+                if (!isset($sumgrades[$attempt['id']])) {
                     return [];
                 }
+                $attempts[$i]['grade'] = round($sumgrades[$attempt['id']] / $quiz->sumgrades * $quiz->grade);
             }
 
             return $attempts;


### PR DESCRIPTION
## Summary

- `VATUSAMoodle::getQuizAttempts()` (duplicated identically in `vatusa/api`) called Moodle's `mod_quiz_get_attempt_review` web service once per attempt to read a single field (`grade`) — but that endpoint returns the *entire* rendered attempt review (every question, every response, ~2.17 MB) per call.
- Driven by scheduled jobs in `api` (`moodle:competency` every 10 min, `moodle:sendexamemails` every 5 min) that share this class, this amounted to \~33,000 calls/day and **\~2 TB/month of outbound traffic** from `academy.vatusa.net` — \~98.6% of that droplet's total egress. This was surfaced while costing out an Azure migration: the bill for that traffic alone (~$193/mo on metered Azure egress) would exceed the entire nonprofit grant.
- The review's `grade` is just `quiz_rescale_grade(sumgrades, quiz)` = `round(sumgrades / quiz.sumgrades * quiz.grade)`. Both `sumgrades` (per attempt, in `mdl_quiz_attempts`) and `quiz.sumgrades`/`quiz.grade` (per quiz, in `mdl_quiz`) already live in the Moodle database this class already queries via `DB::connection('moodle')` for other fields — no need to go over HTTP at all.
- This PR computes the grade from the DB instead: a new `getQuizMeta()` helper (memoized per quiz id for the life of the instance) plus a single batched `whereIn` query for attempt `sumgrades`, replacing the per-attempt review call in `getQuizAttempts()`.
- No behavior change for any consumer: same fields returned, same fail-closed `[]` on missing/unresolvable data.
- Companion PR in `vatusa/api`, which also fixes a second, independent call site there and has a note on a Docker dev-environment quirk found along the way: https://github.com/VATUSA/api/pull/118

## Test plan

- [x] Verified in Docker against a fixture `moodle` database using `api`'s identical class (this repo has no local Docker dev harness of its own — `current`'s only compose file is the production build, per its `CLAUDE.md`): grades match the old review-derived formula exactly for both 1:1 and non-trivially-scaled quizzes, `getQuizMeta()` memoization confirmed, fail-closed behavior preserved for a missing attempt and an unknown quiz id. The change here is identical to the verified `api` change.
- [x] `php -l` syntax check passes. (`current`'s Composer deps aren't installed in this environment, so `phpunit` couldn't be run locally here — `api`'s identical suite passed 18/18.)
- [ ] Post-deploy: confirm `mod_quiz_get_attempt_review` call volume in `academy.vatusa.net`'s Apache access log drops to ~0, and outbound bandwidth drops toward the ~300 GB/month baseline of genuine site traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)